### PR TITLE
Check if the response generates an error

### DIFF
--- a/nut.go
+++ b/nut.go
@@ -56,7 +56,10 @@ func (c *Client) ReadResponse(endLine string, multiLineResponse bool) (resp []st
 
 	for {
 		line, err := connbuff.ReadString('\n')
-		if err == nil && len(line) > 0 {
+		if err != nil {
+			return nil, fmt.Errorf("error reading response: %v", err)
+		}
+		if len(line) > 0 {
 			cleanLine := strings.TrimSuffix(line, "\n")
 			lines := strings.Split(cleanLine, "\n")
 			response = append(response, lines...)


### PR DESCRIPTION
If the call the read the response from the server generates an error, we should return from the function instead of looping indefinitely.

I had a situation where the NUT master's ACL wasn't configured correctly. The master would close the socket connection whenever the client tried to connect. This would cause the client to be stuck in a busy loop.