### PR TITLE
Coax strings that are obvious numbers to float and integer

### DIFF
--- a/ups.go
+++ b/ups.go
@@ -131,7 +131,7 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 		cleanedLine := strings.TrimPrefix(line, offset)
 		splitLine := strings.Split(cleanedLine, `"`)
 		newVar.Name = strings.TrimSuffix(splitLine[0], " ")
-		newVar.Value = splitLine[1]
+		splitLine[1] = strings.TrimSuffix(splitLine[1], " ")
 		if splitLine[1] == "enabled" {
 			newVar.Value = true
 		}

--- a/ups.go
+++ b/ups.go
@@ -134,9 +134,11 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 		splitLine[1] = strings.TrimSuffix(splitLine[1], " ")
 		if splitLine[1] == "enabled" {
 			newVar.Value = true
+			newVar.Type = "BOOLEAN"
 		}
 		if splitLine[1] == "disabled" {
 			newVar.Value = false
+			newVar.Type = "BOOLEAN"
 		}
 		description, err := u.GetVariableDescription(newVar.Name)
 		if err != nil {
@@ -169,6 +171,7 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 			}
 		}
 		if varType == "UNKNOWN" || varType == "NUMBER" {
+			err = nil
 			if strings.Count(splitLine[1], ".") == 1 {
 				converted, err := strconv.ParseFloat(splitLine[1], 64)
 				if err == nil {
@@ -183,6 +186,12 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 					newVar.Type = "INTEGER"
 					newVar.OriginalType = varType
 				}
+			}
+
+			/* Failed to convert either to float or integer - coax to string */
+			if err != nil {
+				newVar.Type = "STRING"
+				newVar.OriginalType = varType
 			}
 		}
 		vars = append(vars, newVar)

--- a/ups.go
+++ b/ups.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"regexp"
 )
 
 // UPS contains information about a specific UPS provided by the NUT instance.
@@ -149,6 +150,24 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 		newVar.Type = varType
 		newVar.Writeable = writeable
 		newVar.MaximumLength = maximumLength
+		if varType == "STRING" {
+			matched, _ := regexp.MatchString(`^[0-9\.]+$`, splitLine[1])
+			if matched && strings.Count(splitLine[1], ".") == 1 {
+				converted, err := strconv.ParseFloat(splitLine[1], 64)
+				if err == nil {
+					newVar.Value = converted
+					newVar.Type = "FLOAT_64"
+					newVar.OriginalType = varType
+				}
+			} else {
+				converted, err := strconv.ParseInt(splitLine[1], 10, 64)
+				if err == nil {
+					newVar.Value = converted
+					newVar.Type = "INTEGER"
+					newVar.OriginalType = varType
+				}
+			}
+		}
 		if varType == "UNKNOWN" || varType == "NUMBER" {
 			if strings.Count(splitLine[1], ".") == 1 {
 				converted, err := strconv.ParseFloat(splitLine[1], 64)


### PR DESCRIPTION
Hi there, @robbiet480. Would you consider this acceptable functionality for this library? I am building a prometheus exporter on top of the library and discovered that my UPS seems a little... silly.

There are things coming back from NUT that are NUMBERs, but related variables coming back as STRINGs.

Example:
```
GET TYPE ups battery.charge.low
TYPE ups battery.charge.low RW STRING:10
GET VAR ups battery.charge.low
VAR ups battery.charge.low "10"

GET TYPE ups battery.charge.warning
TYPE ups battery.charge.warning NUMBER
GET VAR ups battery.charge.warning
VAR ups battery.charge.warning "50"
```

This pull request examines the STRING types that are returned and coaxes them to integer or float64 as is done for `UNKNOWN` and `NUMBER` types. This could be considered a breaking change, so I could wrap this in a static configuration param (or parameter to `GetVariables`) if that would be preferred.