### PR TITLE
Fix: Trim spaces from variable values

### DIFF
--- a/ups.go
+++ b/ups.go
@@ -129,6 +129,7 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 		newVar := Variable{}
 		cleanedLine := strings.TrimPrefix(line, offset)
 		splitLine := strings.Split(cleanedLine, `"`)
+		splitLine[1] = strings.Trim(splitLine[1], " ")
 		newVar.Name = strings.TrimSuffix(splitLine[0], " ")
 		newVar.Value = splitLine[1]
 		if splitLine[1] == "enabled" {


### PR DESCRIPTION
I've noticed that, at least on my silly UPS, some values are returned with trailing spaces within the quotes. This is a quick fix to trim all spaces from such cases.

Example:
```
GET VAR ups device.serial
VAR ups device.serial "4B1538P29631  "
```