### PR TITLE
Align all variables on go types, add BOOLEAN type

### DIFF
--- a/ups.go
+++ b/ups.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"regexp"
 )
 
 // UPS contains information about a specific UPS provided by the NUT instance.
@@ -131,12 +132,7 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 		splitLine := strings.Split(cleanedLine, `"`)
 		newVar.Name = strings.TrimSuffix(splitLine[0], " ")
 		newVar.Value = splitLine[1]
-		if splitLine[1] == "enabled" {
-			newVar.Value = true
-		}
-		if splitLine[1] == "disabled" {
-			newVar.Value = false
-		}
+
 		description, err := u.GetVariableDescription(newVar.Name)
 		if err != nil {
 			return vars, err
@@ -149,7 +145,18 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 		newVar.Type = varType
 		newVar.Writeable = writeable
 		newVar.MaximumLength = maximumLength
-		if varType == "UNKNOWN" || varType == "NUMBER" {
+
+		if splitLine[1] == "enabled" {
+			newVar.Value = true
+			newVar.Type = "BOOLEAN"
+		}
+		if splitLine[1] == "disabled" {
+			newVar.Value = false
+			newVar.Type = "BOOLEAN"
+		}
+
+		matched, _ := regexp.MatchString(`^-?[0-9\.]+$`, splitLine[1])
+		if matched {
 			if strings.Count(splitLine[1], ".") == 1 {
 				converted, err := strconv.ParseFloat(splitLine[1], 64)
 				if err == nil {
@@ -166,6 +173,13 @@ func (u *UPS) GetVariables() ([]Variable, error) {
 				}
 			}
 		}
+
+		/* Failed conversion or not a numeric value - coax to STRING */
+		if err != nil || !matched {
+			newVar.Type = "STRING"
+			newVar.OriginalType = varType
+		}
+
 		vars = append(vars, newVar)
 	}
 	u.Variables = vars


### PR DESCRIPTION
Hi there, @robbiet480. Perhaps this is a worthy addition... this PR aligns `Variable.Type`s on go primitive types. The PR makes minor modifications to existing logic such that:
* Items coaxed to boolean are set to `BOOLEAN` in the type
* Number-like values (regardless of TYPE returned by NUT) are coaxed to `INTEGER` or `FLOAT_64`
* All other types are converted to `STRING` type
* Original types are preserved for consumers that want to know what NUT believes the type should be

The reasoning behind this is that, at least for my silly UPS, some numeric values are typed as STRINGs rather than NUMBER. This leads me to think that the typing system in NUT is perhaps too flexible and can be implemented incorrectly in some drivers or UPSs.

Example:
```
GET TYPE ups battery.charge.low
TYPE ups battery.charge.low RW STRING:10
GET VAR ups battery.charge.low
VAR ups battery.charge.low "10"

GET TYPE ups battery.charge.warning
TYPE ups battery.charge.warning NUMBER
GET VAR ups battery.charge.warning
VAR ups battery.charge.warning "50"
```