### PR TITLE
allow an optional port parameter

### DIFF
--- a/nut.go
+++ b/nut.go
@@ -18,9 +18,13 @@ type Client struct {
 	conn            *net.TCPConn
 }
 
-// Connect accepts a hostname/IP string and creates a connection to NUT, returning a Client.
-func Connect(hostname string) (Client, error) {
-	tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:3493", hostname))
+// Connect accepts a hostname/IP string and an optional port, then creates a connection to NUT, returning a Client.
+func Connect(hostname string, _port ...int) (Client, error) {
+	port := 3493
+	if len(_port) > 0 {
+		port = _port[0]
+	}
+	tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", hostname, port))
 	if err != nil {
 		return Client{}, err
 	}


### PR DESCRIPTION
I just need to connect with a port number different than the default.
Usually you do this:
`
upsClient, err = nut.Connect("192.168.1.33")
`
With this modification you can ALSO do this:
`
upsClient, err = nut.Connect("192.168.1.33", 3333)
`

Being an optional parameter it should not break anything.