### PR TITLE
Guard against errors and empty responses from NUT server before referencing response index

### DIFF
--- a/nut.go
+++ b/nut.go
@@ -139,12 +139,18 @@ func (c *Client) GetUPSList() ([]UPS, error) {
 // Help returns a list of the commands supported by NUT.
 func (c *Client) Help() (string, error) {
 	helpResp, err := c.SendCommand("HELP")
+	if err != nil || len(helpResp) < 1 {
+		return "", err
+	}
 	return helpResp[0], err
 }
 
 // GetVersion returns the the version of the server currently in use.
 func (c *Client) GetVersion() (string, error) {
 	versionResponse, err := c.SendCommand("VER")
+	if err != nil || len(versionResponse) < 1 {
+		return "", err
+	}
 	c.Version = versionResponse[0]
 	return versionResponse[0], err
 }
@@ -152,6 +158,9 @@ func (c *Client) GetVersion() (string, error) {
 // GetNetworkProtocolVersion returns the version of the network protocol currently in use.
 func (c *Client) GetNetworkProtocolVersion() (string, error) {
 	versionResponse, err := c.SendCommand("NETVER")
+	if err != nil || len(versionResponse) < 1 {
+		return "", err
+	}
 	c.ProtocolVersion = versionResponse[0]
 	return versionResponse[0], err
 }


### PR DESCRIPTION
In some places, the response array is indexed before verifying no error was returned from [bufio.ReadString](https://pkg.go.dev/bufio#Reader.ReadString). Tracing the code back, the only guard that *should* be required is a check that `err` is not nil - otherwise the array should always have something in it... but I figured, "Heck... let's also guard against an empty array just in case, too"